### PR TITLE
Avoid error cannot read property push of undefined

### DIFF
--- a/lib/modules/getMessage.js
+++ b/lib/modules/getMessage.js
@@ -31,12 +31,14 @@ function emit(instance, channel, message) {
   var messages = instance._component.state.pn_messages[channel];
   var keepMessages = instance._keepMessages[channel];
 
-  messages.push(message);
+  if (messages) {
+    messages.push(message);
 
-  if (keepMessages && messages.length > keepMessages) {
-    messages = messages.slice(messages.length - keepMessages);
+    if (keepMessages && messages.length > keepMessages) {
+      messages = messages.slice(messages.length - keepMessages);
+    }
   }
-
+    
   instance._component.setState(function (prevState) {
     return {
       pn_messages: (0, _immutabilityHelper2.default)(prevState.pn_messages, _defineProperty({}, channel, { $set: messages }))


### PR DESCRIPTION
When trying to push a message to the "messages" array, the code threw an error when this array was undefined. Better to check that the array actually exists and so that content can be pushed to it.